### PR TITLE
better nominate

### DIFF
--- a/CrossCutting/MapLister.cs
+++ b/CrossCutting/MapLister.cs
@@ -65,6 +65,9 @@ namespace cs2_rockthevote
         // otherwise, returns the macting name
         public string GetSingleMatchingMapName(string map, CCSPlayerController player, StringLocalizer _localizer)
         {
+            if (this.Maps!.Select(x => x.Name).FirstOrDefault(x => x.ToLower() == map) is not null)
+                return map;
+
             var matchingMaps = this.Maps!
                 .Select(x => x.Name)
                 .Where(x => x.ToLower().Contains(map.ToLower()))

--- a/CrossCutting/MapLister.cs
+++ b/CrossCutting/MapLister.cs
@@ -1,4 +1,6 @@
-﻿using cs2_rockthevote.Core;
+﻿using CounterStrikeSharp.API.Modules.Entities;
+using cs2_rockthevote.Core;
+using CounterStrikeSharp.API.Core;
 
 namespace cs2_rockthevote
 {
@@ -57,6 +59,29 @@ namespace cs2_rockthevote
         {
             _plugin = plugin;
             LoadMaps();
+        }
+
+        // returns "" if there's no matching or if there's more than one
+        // otherwise, returns the macting name
+        public string GetSingleMatchingMapName(string map, CCSPlayerController player, StringLocalizer _localizer)
+        {
+            var matchingMaps = this.Maps!
+                .Select(x => x.Name)
+                .Where(x => x.ToLower().Contains(map.ToLower()))
+                .ToList();
+
+            if (matchingMaps.Count == 0)
+            {
+                player!.PrintToChat(_localizer.LocalizeWithPrefix("general.invalid-map"));
+                return "";
+            }
+            else if (matchingMaps.Count > 1)
+            {
+                player!.PrintToChat(_localizer.LocalizeWithPrefix("nominate.multiple-maps-containing-name"));
+                return "";
+            }
+            
+            return matchingMaps[0];
         }
     }
 }

--- a/Features/NominationCommand.cs
+++ b/Features/NominationCommand.cs
@@ -118,23 +118,10 @@ namespace cs2_rockthevote
                 return;
             }
 
-            var matchingMaps = _mapLister.Maps!
-                .Select(x => x.Name)
-                .Where(x => x.ToLower().Contains(map.ToLower()))
-                .ToList();
+            string matchingMap = _mapLister.GetSingleMatchingMapName(map, player, _localizer);
 
-            if (matchingMaps.Count == 0)
-            {
-                player!.PrintToChat(_localizer.LocalizeWithPrefix("general.invalid-map"));
+            if (matchingMap == "")
                 return;
-            }
-            else if (matchingMaps.Count > 1)
-            {
-                player!.PrintToChat(_localizer.LocalizeWithPrefix("nominate.multiple-maps-containing-name"));
-                return;
-            }
-
-            string matchingMap = matchingMaps[0];
 
             var userId = player.UserId!.Value;
             if (!Nominations.ContainsKey(userId))

--- a/Features/NominationCommand.cs
+++ b/Features/NominationCommand.cs
@@ -118,28 +118,39 @@ namespace cs2_rockthevote
                 return;
             }
 
-            if (_mapLister.Maps!.Select(x => x.Name).FirstOrDefault(x => x.ToLower() == map) is null)
+            var matchingMaps = _mapLister.Maps!
+                .Select(x => x.Name)
+                .Where(x => x.ToLower().Contains(map.ToLower()))
+                .ToList();
+
+            if (matchingMaps.Count == 0)
             {
                 player!.PrintToChat(_localizer.LocalizeWithPrefix("general.invalid-map"));
                 return;
-
             }
+            else if (matchingMaps.Count > 1)
+            {
+                player!.PrintToChat(_localizer.LocalizeWithPrefix("nominate.multiple-maps-containing-name"));
+                return;
+            }
+
+            string matchingMap = matchingMaps[0];
 
             var userId = player.UserId!.Value;
             if (!Nominations.ContainsKey(userId))
                 Nominations[userId] = new();
 
-            bool alreadyVoted = Nominations[userId].IndexOf(map) != -1;
+            bool alreadyVoted = Nominations[userId].IndexOf(matchingMap) != -1;
             if (!alreadyVoted)
-                Nominations[userId].Add(map);
+                Nominations[userId].Add(matchingMap);
 
-            var totalVotes = Nominations.Select(x => x.Value.Where(y => y == map).Count())
+            var totalVotes = Nominations.Select(x => x.Value.Where(y => y == matchingMap).Count())
                 .Sum();
 
             if (!alreadyVoted)
-                Server.PrintToChatAll(_localizer.LocalizeWithPrefix("nominate.nominated", player.PlayerName, map, totalVotes));
+                Server.PrintToChatAll(_localizer.LocalizeWithPrefix("nominate.nominated", player.PlayerName, matchingMap, totalVotes));
             else
-                player.PrintToChat(_localizer.LocalizeWithPrefix("nominate.already-nominated", map, totalVotes));
+                player.PrintToChat(_localizer.LocalizeWithPrefix("nominate.already-nominated", matchingMap, totalVotes));
         }
 
         public List<string> NominationWinners()

--- a/lang/en.json
+++ b/lang/en.json
@@ -18,6 +18,7 @@
   "general.invalid-map": "Invalid map",
   "nominate.nominated": "Player {green}{0}{default} nominated map {green}{1}{default}, now it has {2} vote(s)",
   "nominate.already-nominated": "You already nominated the map {green}{0}{default}, it has {1} vote(s)",
+  "nominate.multiple-maps-containing-name": "There's more than one map with the given name",
   "general.validation.current-map": "You can't choose the current map",
   "general.validation.minimum-rounds": "Minimum rounds to use this command is {0}",
   "general.validation.warmup": "Command disabled during warmup.",

--- a/lang/hu.json
+++ b/lang/hu.json
@@ -18,6 +18,7 @@
   "general.invalid-map": "Érvénytelen pálya",
   "nominate.nominated": "{green}{0}{default} ezt a pályát ajánlotta: {green}{1}{default}, jelenleg {2} szavazata van",
   "nominate.already-nominated": "Már ajánlottad ezt a pályát: {green}{0}{default}, jelenleg {1} szavazata van",
+  "nominate.multiple-maps-containing-name": "Több térkép van a megadott névvel, légy pontosabb!",
   "general.validation.current-map": "A jelenlegi pályát nem tudod kiválasztani",
   "general.validation.minimum-rounds": "Ehhez a parancshoz a minimum körök száma: {0}",
   "general.validation.warmup": "Bemelegítés alatt nem használható ez a parancs.",

--- a/lang/lv.json
+++ b/lang/lv.json
@@ -18,6 +18,7 @@
   "general.invalid-map": "Neatbilstoša karte",
   "nominate.nominated": "Spēlētājs {green}{0}{default} izvirzija karti {green}{1}{default}, šobrīd ir tai ir {2} balss(is)",
   "nominate.already-nominated": "Tu jau izvirzīji karti {green}{0}{default}, tai ir {1} balss(is)",
+  "nominate.multiple-maps-containing-name": "Ir vairāki kartes ar dotajiem nosaukumiem, būsiet precīzāki!",
   "general.validation.current-map": "Tu nevari izvēlēties karti kas šobrīd tiek spēlēta",
   "general.validation.minimum-rounds": "Jānospēlē raundi {0} lai izmantotu šo komandu",
   "general.validation.warmup": "Komanda nav pieejama warmup laikā.",

--- a/lang/pl.json
+++ b/lang/pl.json
@@ -18,6 +18,7 @@
   "general.invalid-map": "Nieprawidłowa mapa",
   "nominate.nominated": "Gracz {green}{0}{default} nominował mapę {green}{1}{default}, obecnie ma {2} głos(y)",
   "nominate.already-nominated": "Już nominowałeś mapę {green}{0}{default}, ma {1} głos(y)",
+  "nominate.multiple-maps-containing-name": "Istnieje więcej niż jedna mapa o podanej nazwie, proszę być bardziej konkretan!",
   "general.validation.current-map": "Nie możesz wybrać obecnej mapy",
   "general.validation.minimum-rounds": "Minimalna liczba rund do użycia tej komendy to {0}",
   "general.validation.warmup": "Komenda wyłączona podczas rozgrzewki.",

--- a/lang/pt-BR.json
+++ b/lang/pt-BR.json
@@ -18,6 +18,7 @@
   "general.invalid-map": "Mapa inválido",
   "nominate.nominated": "O jogador {green}{0}{default} indicou o mapa {green}{1}{default}, agora ele tem {2} voto(s)",
   "nominate.already-nominated": "Você já indicou o mapa {green}{0}{default}, ele tem {1} voto(s)",
+  "nominate.multiple-maps-containing-name": "Há mais de um mapa com o nome fornecido, seja mais específico!",
   "general.validation.current-map": "Você não pode escolher o mapa atual",
   "general.validation.minimum-rounds": "O número mínimo de rounds para usar este comando é {0}",
   "general.validation.warmup": "Comando desativado durante o aquecimento.",

--- a/lang/ru.json
+++ b/lang/ru.json
@@ -18,6 +18,7 @@
   "general.invalid-map": "Неверная карта",
   "nominate.nominated": "Игрок {green}{0}{default} предложил карту {green}{1}{default}, сейчас она имеет {2} голосов",
   "nominate.already-nominated": "Вы уже предложили эту карту {green}{0}{default}, она имеет {1} голосов",
+  "nominate.multiple-maps-containing-name": "Больше одной карты с данным именем, уточните!",
   "general.validation.current-map": "Вы не можете выбрать текущую карту",
   "general.validation.minimum-rounds": "Минимальное количество раундов для использования этой команды {0}",
   "general.validation.warmup": "Команда отключена во время разминки",

--- a/lang/tr.json
+++ b/lang/tr.json
@@ -18,6 +18,7 @@
   "general.invalid-map": "Geçersiz harita",
   "nominate.nominated": "Oyuncu {green}{0}{default}, {green}{1}{default} haritasını aday gösterdi, şimdi {2} oyu var",
   "nominate.already-nominated": "{green}{0}{default} haritasını zaten aday gösterdiniz, {1} oyu var",
+  "nominate.multiple-maps-containing-name": "Verilen isme sahip birden fazla harita var, daha belirgin olun!",
   "general.validation.current-map": "Mevcut haritayı seçemezsiniz",
   "general.validation.minimum-rounds": "Bu komutu kullanmak için minimum tur sayısı {0}",
   "general.validation.warmup": "Isınma sırasında komut devre dışı bırakıldı.",

--- a/lang/ua.json
+++ b/lang/ua.json
@@ -18,6 +18,7 @@
   "general.invalid-map": "Неприпустима карта",
   "nominate.nominated": "Гравець {green}{0}{default} висунув кандидатуру карти {green}{1}{default}, зараз у неї {2} голосів",
   "nominate.already-nominated": "Ви вже висунули кандидатуру карти {green}{0}{default}, зараз у неї {1} голос(ів)",
+  "nominate.multiple-maps-containing-name": "Є більше однієї карти з вказаною назвою, будьте точніше!",
   "general.validation.current-map": "Ви не можете обирати поточну карту",
   "general.validation.minimum-rounds": "Мінімум раундів для використання цієї команди - {0}",
   "general.validation.warmup": "Команда вимкнена під час розігріву",


### PR DESCRIPTION
+ Find the map with string containing the given name
+ Added translation (with ChatGPT) for the case of multiple maps with the same given name

*Example: Before, the `!nominate swag` command didn't return any maps
![Captura de tela 2024-02-27 002124](https://github.com/abnerfs/cs2-rockthevote/assets/62575526/0f7658d8-e72c-48e5-b348-ef52b92ec863)