### PR TITLE
Update OnRoundEndMapChanger

### DIFF
--- a/Core/ChangeMapManager.cs
+++ b/Core/ChangeMapManager.cs
@@ -10,7 +10,7 @@ namespace cs2_rockthevote
         [GameEventHandler(HookMode.Post)]
         public HookResult OnRoundEndMapChanger(EventRoundEnd @event, GameEventInfo info)
         {
-            _changeMapManager.ChangeNextMap();
+            _changeMapManager.ChangeNextMap(mapEnd: true);
             return HookResult.Continue;
         }
 

--- a/Plugin.cs
+++ b/Plugin.cs
@@ -21,7 +21,7 @@ namespace cs2_rockthevote
     public partial class Plugin : BasePlugin, IPluginConfig<Config>
     {
         public override string ModuleName => "RockTheVote";
-        public override string ModuleVersion => "1.8.5";
+        public override string ModuleVersion => "1.8.6";
         public override string ModuleAuthor => "abnerfs";
         public override string ModuleDescription => "https://github.com/abnerfs/cs2-rockthevote";
 


### PR DESCRIPTION
Change the default mapEnd var for the OnRounEndMapChanger because if the end of map vote happens it schedules the map change and sets the internal value to true so this change will allow the map to change at the end of the round.