### PR TITLE
Add ability to trigger a map vote externally

### DIFF
--- a/Core/EndMapVoteManager.cs
+++ b/Core/EndMapVoteManager.cs
@@ -51,6 +51,7 @@ namespace cs2_rockthevote
         List<string> mapsEllected = new();
 
         private IEndOfMapConfig? _config = null;
+        private IEndOfMapConfig? _configBackup = null;
         private int _canVote = 0;
         private Plugin? _plugin;
 
@@ -68,6 +69,13 @@ namespace cs2_rockthevote
             timeLeft = 0;
             mapsEllected.Clear();
             KillTimer();
+
+            // Restore the config if it was changed by the server command
+            if (_configBackup is not null)
+            {
+                _config = _configBackup;
+                _configBackup = null;
+            }
         }
 
         public void MapVoted(CCSPlayerController player, string mapName)
@@ -178,6 +186,9 @@ namespace cs2_rockthevote
         {
             Votes.Clear();
             _voted.Clear();
+
+            // Backup the current config as if this is called via the server command, the config will be changed
+            _configBackup = _config;
 
             _pluginState.EofVoteHappening = true;
             _config = config;

--- a/README.md
+++ b/README.md
@@ -128,6 +128,10 @@ de_thera:3121217565
 de_dust2
 ```
 
+# Server commands
+
+- rtv [seconds] - Trigger a map vote externally that will change the map immediately with an optional seconds parameter for voting duration (useful for gamemodes like GunGame)
+
 # Limitations
  - Plugins is still under development and a lot of functionality is still going to be added in the future.
  - I usually test the new versions in an empty server with bots so it is hard to tell if everything is actually working, feel free to post any issues here or in the discord thread so I can fix them https://discord.com/channels/1160907911501991946/1176224458751627514


### PR DESCRIPTION
Add ability to trigger a map vote externally that will change the map immediately with an optional seconds parameter for voting duration (useful for gamemodes like GunGame)